### PR TITLE
Fix scenario where file type icon can not be found

### DIFF
--- a/views/snippet.pug
+++ b/views/snippet.pug
@@ -10,7 +10,7 @@ html
             div(class='snippet-tab-container')
                 each file in files
                     button(class=(file.filename === slice.file) ? 'snippet-tab snippet-tab--active' : 'snippet-tab', data-file=file.filename)
-                        img(src=file.icon, alt="Coding language icon", class="snippet-tab-file-icon")
+                        img(src=file.icon, onerror="this.onerror=null; this.src='https://raw.githubusercontent.com/jesseweed/seti-ui/master/icons/html.svg'", alt="Coding language icon", class="snippet-tab-file-icon")
                         span(class='snippet-tab-name')= file.filename
         div(class='snippet-data')
             each file in files


### PR DESCRIPTION
### Completed
- Configure pug template to use default file type icon (.html) if there is an error resolving the icon.

<!-- Include a demo of your changes if you have one -->
### Demo
![image](https://user-images.githubusercontent.com/9601620/88981131-2b266100-d27a-11ea-9cae-e9ccd77403e4.png)

<!-- Include issues that are closed by this PR -->
Closes #42